### PR TITLE
Mexor Solution Added

### DIFF
--- a/Codechef Solution/mexor.cpp
+++ b/Codechef Solution/mexor.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include<cmath>
+using namespace std;
+
+int main() {
+  int t; cin>>t;
+  while(t--){
+      int m;
+      cin>>m;
+      bool flag=true;
+      int count=0,x=m;
+      if(x==0){
+      cout<<"1"<<endl;
+      continue;
+      }
+      while(x!=0)
+      {
+          int l=x%2;
+          if(l==0)
+          flag=false;
+          
+          x/=2;
+          count++;
+      }
+     
+      if(flag) cout<<m+1<<endl;
+       else{
+          int sum=0;
+          count--;
+          while(count--){
+              sum+=pow(2,count);
+          }
+          cout<<sum+1<<endl;
+      }
+  }
+  return 0;
+}


### PR DESCRIPTION
The MEX (minimum excluded) of an array is the smallest non-negative integer that does not belong to the array. For instance:

The MEX of [2,2,1] is 0, because 0 does not belong to the array.
The MEX of [3,1,0,1] is 2, because 0 and 1 belong to the array, but 2 does not.
The MEX of [0,3,1,2] is 4 because 0,1,2 and 3 belong to the array, but 4 does not.
Find the maximum possible MEX of an array of non-negative integers such that the bitwise OR of the elements in the array does not exceed X.

